### PR TITLE
Ability to select and copy accounts out of Trunkfriends

### DIFF
--- a/src/main/kotlin/org/osprey/trunkfriends/historyhandler/HistoryMain.kt
+++ b/src/main/kotlin/org/osprey/trunkfriends/historyhandler/HistoryMain.kt
@@ -40,7 +40,7 @@ suspend fun refresh(selectedConfig : Pair<String, Config>, isCancelled : () -> B
     } catch (e : Exception) {
         feedbackFunction("Error during fetch, list not updated\n\n")
         feedbackFunction("Error: ${e.message}\n\n")
-        delay(1000L)
+        delay(10000L)
     }
 
 }

--- a/src/main/kotlin/org/osprey/trunkfriends/ui/TrunkUI.kt
+++ b/src/main/kotlin/org/osprey/trunkfriends/ui/TrunkUI.kt
@@ -18,6 +18,7 @@ import org.osprey.trunkfriends.config.Config
 import org.osprey.trunkfriends.ui.authenticate.AuthState
 import org.osprey.trunkfriends.ui.authenticate.authenticateView
 import org.osprey.trunkfriends.ui.history.historyListing
+import org.osprey.trunkfriends.ui.history.pasteView
 import org.osprey.trunkfriends.util.mapper
 import java.io.File
 import java.nio.file.Files
@@ -27,6 +28,11 @@ import java.nio.file.Paths
 @Preview
 fun App(state: UIState) {
 
+    // Todo: startpoint for scalable UI
+    /*val configuration = LocalConfiguration.current
+
+    val screenHeight = configuration.screenHeightDp.dp
+    val screenWidth = configuration.screenWidthDp.dp*/
     Column(Modifier.background(colorBackground).fillMaxHeight()) {
 
         if (state.view == "Add server") {
@@ -58,6 +64,9 @@ fun App(state: UIState) {
         if (state.view == "Refresh") {
             refreshView(state)
         }
+        if (state.view == "Pastebag") {
+            pasteView(state)
+        }
     }
 }
 
@@ -75,6 +84,10 @@ fun ButtonRowHeader(state : UIState) {
             CommonButton(enabled = state.activeButtons, text = "Refresh followers") {
                 state.view = "Refresh"
             }
+            CommonButton(enabled = state.activeButtons, text = "(${state.historyViewState.pasteBag.size}) Bag") {
+                state.view = "Pastebag"
+            }
+
         }
 
         Button(

--- a/src/main/kotlin/org/osprey/trunkfriends/ui/UIState.kt
+++ b/src/main/kotlin/org/osprey/trunkfriends/ui/UIState.kt
@@ -17,7 +17,6 @@ class UIState(var configMap: MutableList<Pair<String, Config>>) {
     var zoomedName by mutableStateOf<String?>(null)
     var view by mutableStateOf("About")
     var activeButtons by mutableStateOf(true)
-
     private var coroutineScope = CoroutineScope(Dispatchers.Main)
 
     var refreshActive = false
@@ -50,4 +49,15 @@ class UIState(var configMap: MutableList<Pair<String, Config>>) {
         view = selectView
     }
 
+    fun clearSelect() {
+        historyViewState.pasteBag.clear()
+    }
+
+    fun getSelected(limit : Int = 0) =
+        if (historyViewState.pasteBag.isEmpty())
+            ""
+        else if (limit == 0)
+            historyViewState.pasteBag.reduce { acc, s -> "$acc\n$s" }
+        else
+            historyViewState.pasteBag.take(limit).reduce { acc, s -> "$acc\n$s" }
 }

--- a/src/main/kotlin/org/osprey/trunkfriends/ui/history/HistoryViewState.kt
+++ b/src/main/kotlin/org/osprey/trunkfriends/ui/history/HistoryViewState.kt
@@ -1,8 +1,6 @@
 package org.osprey.trunkfriends.ui.history
 
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.*
 
 class HistoryViewState {
     var page by mutableStateOf(0)
@@ -10,6 +8,7 @@ class HistoryViewState {
     var timeslotPage by mutableStateOf(0)
     var historyDropdownState by mutableStateOf(false)
     var time by mutableStateOf(0L)
+    val pasteBag = mutableStateListOf<String>()
 
     fun reset() {
         page = 0

--- a/src/main/kotlin/org/osprey/trunkfriends/ui/history/historyListing.kt
+++ b/src/main/kotlin/org/osprey/trunkfriends/ui/history/historyListing.kt
@@ -162,7 +162,7 @@ fun zoomButton(text: String, onClick: () -> Unit) {
                 backgroundColor = Color.White,
                 contentColor = Color.Black
             ),
-        modifier = Modifier.padding(0.dp).height(25.dp).width(100.dp),
+        modifier = Modifier.padding(0.dp).height(25.dp),
         onClick = { onClick() },
     ) {
         Text(text, fontSize = 7.sp)
@@ -221,12 +221,20 @@ fun followCard(
                     }
                 }
                 Column {
-                    Row(modifier = Modifier.width(500.dp)) {
+                    Row(modifier = Modifier.width(450.dp)) {
                         Text(text = acct)
                     }
                 }
-                zoomButton(text = "\uD83D\uDD0D") {
-                    onNameChange(acct)
+                Column {
+                    Checkbox(
+                        checked = false,
+                        onCheckedChange = { }
+                    )
+                }
+                Column {
+                    zoomButton(text = "\uD83D\uDD0D") {
+                        onNameChange(acct)
+                    }
                 }
             }
         }

--- a/src/main/kotlin/org/osprey/trunkfriends/ui/history/historyListing.kt
+++ b/src/main/kotlin/org/osprey/trunkfriends/ui/history/historyListing.kt
@@ -127,10 +127,10 @@ server with requests. Once followers are imported, you will be see them here.
                             if (zoomedName != null) {
                                 Column {
                                     Text("⏰ ${timestampToDateString(historyCard.timeStamp)}")
-                                    followCard(historyCard, onNameChange)
+                                    followCard(historyCard, historyState, onNameChange)
                                 }
                             } else {
-                                followCard(historyCard) {
+                                followCard(historyCard, historyState) {
                                     onNameChange(it)
                                     historyState.storeHistoryPage()
                                 }
@@ -172,6 +172,7 @@ fun zoomButton(text: String, onClick: () -> Unit) {
 @Composable
 fun followCard(
     historyCard: HistoryCard,
+    historyState: HistoryViewState,
     onNameChange: (String?) -> Unit
 ) {
     Card(
@@ -227,8 +228,14 @@ fun followCard(
                 }
                 Column {
                     Checkbox(
-                        checked = false,
-                        onCheckedChange = { }
+                        checked = historyState.pasteBag.contains(acct),
+                        onCheckedChange = {
+                            if (historyState.pasteBag.contains(acct)) {
+                                historyState.pasteBag.remove(acct)
+                            } else {
+                                historyState.pasteBag.add(acct)
+                            }
+                        }
                     )
                 }
                 Column {

--- a/src/main/kotlin/org/osprey/trunkfriends/ui/history/pasteView.kt
+++ b/src/main/kotlin/org/osprey/trunkfriends/ui/history/pasteView.kt
@@ -1,0 +1,67 @@
+package org.osprey.trunkfriends.ui.history
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ClipboardManager
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.TextUnitType
+import androidx.compose.ui.unit.dp
+import org.osprey.trunkfriends.ui.*
+
+
+@Composable
+fun pasteView(state: UIState) {
+    val clipboardManager: ClipboardManager = LocalClipboardManager.current
+    Text("\n")
+
+    Row(
+        modifier = Modifier
+            .border(width = 2.dp, color = colorTwo)
+            .background(colorOne).fillMaxWidth()
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text(
+                modifier = Modifier.align(Alignment.CenterHorizontally),
+                text = "Below is the accounts selected (max 15 displayed)\n",
+                fontSize = TextUnit(20f, TextUnitType.Sp)
+            )
+            Text(
+                modifier = Modifier.align(Alignment.CenterHorizontally),
+                text = state.getSelected(15)+"\n",
+                fontSize = TextUnit(18f, TextUnitType.Sp)
+            )
+
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth(1f)
+            .background(colorTwo)
+            .verticalScroll(rememberScrollState())
+    ) {
+        Row(modifier = Modifier.fillMaxWidth()) {
+            CommonButton(text = "Copy accounts to clipboard") {
+                clipboardManager.setText(
+                    AnnotatedString(state.getSelected())
+                )
+            }
+            CommonButton(text = "Clear selections") {
+                state.clearSelect()
+            }
+
+        }
+    }
+
+}


### PR DESCRIPTION
The ability to track what connections you have lost is one thing, but it gets kinda annoying
if you need to manually write the account names you have found in Trunkfriends elsewhere
to refollow them from another account.

This commit lets you select one or more accounts, and copy them to the clipboard, so you
can paste them wherever you want.